### PR TITLE
add preserve attribute to settings

### DIFF
--- a/Forms9Patch/Forms9Patch.Droid/Models/Settings.cs
+++ b/Forms9Patch/Forms9Patch.Droid/Models/Settings.cs
@@ -15,6 +15,7 @@ namespace Forms9Patch.Droid
     /// <summary>
     /// Forms9Patch Settings.
     /// </summary>
+    [Preserve(AllMembers = true)]
     public class Settings : ISettings
     {
         #region Properties

--- a/Forms9Patch/Forms9Patch.iOS/Models/Settings.cs
+++ b/Forms9Patch/Forms9Patch.iOS/Models/Settings.cs
@@ -13,6 +13,7 @@ namespace Forms9Patch.iOS
     /// <summary>
     /// Forms9Patch Settings.
     /// </summary>
+    [Preserve(AllMembers = true)]
     public class Settings : ISettings
     {
         #region Fields

--- a/Forms9Patch/Forms9Patch/Interfaces/ISettings.cs
+++ b/Forms9Patch/Forms9Patch/Interfaces/ISettings.cs
@@ -7,6 +7,7 @@ namespace Forms9Patch
     /// <summary>
     /// Interface for platform settings
     /// </summary>
+    [Preserve(AllMembers = true)]
     public interface ISettings
     {
         /// <summary>

--- a/Forms9Patch/Forms9Patch/Models/Settings.cs
+++ b/Forms9Patch/Forms9Patch/Models/Settings.cs
@@ -12,6 +12,7 @@ namespace Forms9Patch
     /// Forms9Patch Settings (for use by Forms9Patch PCL code).
     /// </summary>
     [DesignTimeVisible(true)]
+    [Preserve(AllMembers = true)]
     public static class Settings
     {
         static Settings()
@@ -99,9 +100,9 @@ namespace Forms9Patch
                 platformSettings.LazyInit();
                 _confirmed = true;
             }
-
+            
             if (!_confirmed)
-                throw new Exception("Unable to confirmed initialization.  Did you forget to add " +
+                throw new Exception("Unable to confirm initialization.  Did you forget to add " +
                     "Forms9Patch." + Device.RuntimePlatform + ".Settings.Initialize() after XamarinForms.Forms.Forms.Init()?");
         }
         #endregion

--- a/Forms9Patch/Forms9Patch/PreserveAttribute.cs
+++ b/Forms9Patch/Forms9Patch/PreserveAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Forms9Patch
+{
+    /// <summary>
+    /// Attribute that makes sure classes are preserved by the linker
+    /// </summary>
+    internal sealed class PreserveAttribute : System.Attribute
+    {
+        public bool AllMembers;
+        public bool Conditional;
+    }
+}


### PR DESCRIPTION
Solves a problem with the linker when set to full linking. The dependency service could no longer resolve the settings class, this is solved by adding the preserve attribute