### PR TITLE
Fix for when the same fonts exist in both system and assets or resource

### DIFF
--- a/Forms9Patch/Forms9Patch.Droid/Models/FontManagment.cs
+++ b/Forms9Patch/Forms9Patch.Droid/Models/FontManagment.cs
@@ -171,8 +171,9 @@ namespace Forms9Patch.Droid
         {
             var loadedFonts = new Dictionary<string, string>();
             loadedFonts.AddRange(SystemFontFiles);
-            loadedFonts.AddRange(AssetFontFiles);
-            loadedFonts.AddRange(ResourceFontFiles);
+            loadedFonts.AddRange(AssetFontFiles?.Where(x => !loadedFonts.ContainsKey(x.Key)));
+            loadedFonts.AddRange(ResourceFontFiles?.Where(x => !loadedFonts.ContainsKey(x.Key)));
+
             return loadedFonts;
         }
 


### PR DESCRIPTION
It is possible for the same fonts to exist both on the system and as an asset or resource. This is specifically the case for Roboto on earlier Android versions in combination with Syncfusion that also includes the font, resulting in a crash when a label triggers the FontManagement class. This fix simply de-duplicates the three lists by only adding keys that do not yet exist.