### PR TITLE
Android WebView Bug

### DIFF
--- a/Forms9Patch/Forms9Patch.Droid/Services/ToPngService.cs
+++ b/Forms9Patch/Forms9Patch.Droid/Services/ToPngService.cs
@@ -318,6 +318,7 @@ namespace Forms9Patch.Droid
         public override void OnLoadResource(Android.Webkit.WebView view, string url)
         {
             System.Diagnostics.Debug.WriteLine("WebViewCallBack" + P42.Utils.ReflectionExtensions.CallerString() + ": ");
+            Task.Delay(1000).Wait();
             base.OnLoadResource(view, url);
             Device.StartTimer(TimeSpan.FromSeconds(10), () =>
             {


### PR DESCRIPTION
On some phones with Android 10, depending on the version of WebView, the page saved on the device is completely blank, as there was no time to load the HTML. It is a bug in WebView, however with this change in the code I was able to solve the problem in the application I develop.